### PR TITLE
Add sendPlayerToArgSpawn

### DIFF
--- a/src/main/java/net/cubespace/geSuit/database/Spawns.java
+++ b/src/main/java/net/cubespace/geSuit/database/Spawns.java
@@ -36,6 +36,29 @@ public class Spawns implements IRepository {
         return location;
     }
 
+    public Location getServerSpawn(String spawnName, String serverName) {
+        ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
+        Location location = null;
+
+        try {
+            PreparedStatement getServerSpawn = connectionHandler.getPreparedStatement("getServerSpawn");
+            getServerSpawn.setString(1, spawnName);
+            getServerSpawn.setString(2, serverName);
+
+            ResultSet res = getServerSpawn.executeQuery();
+            while (res.next()) {
+                location = new Location(res.getString("server"), res.getString("world"), res.getDouble("x"), res.getDouble("y"), res.getDouble("z"), res.getFloat("yaw"), res.getFloat("pitch"));
+            }
+            res.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            connectionHandler.release();
+        }
+
+        return location;
+    }
+
     public void deleteWorldSpawn(String server, String world) {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
@@ -135,6 +158,7 @@ public class Spawns implements IRepository {
     @Override
     public void registerPreparedStatements(ConnectionHandler connection) {
         connection.addPreparedStatement("getSpawn", "SELECT * FROM "+ ConfigManager.main.Table_Spawns +" WHERE spawnname=?");
+        connection.addPreparedStatement("getServerSpawn", "SELECT * FROM "+ ConfigManager.main.Table_Spawns +" WHERE spawnname=? AND server=?");
         connection.addPreparedStatement("getSpawnsForServer", "SELECT * FROM "+ ConfigManager.main.Table_Spawns +" WHERE server=? AND NOT (spawnname = 'NewPlayerSpawn' OR spawnname = 'ProxySpawn')");
         connection.addPreparedStatement("insertSpawn", "INSERT INTO "+ ConfigManager.main.Table_Spawns +" (spawnname, server, world, x, y, z, yaw, pitch) VALUES(?,?,?,?,?,?,?,?)");
         connection.addPreparedStatement("updateSpawn", "UPDATE "+ ConfigManager.main.Table_Spawns +" SET world = ?, x = ?, y = ?, z = ?, yaw = ?, pitch = ? WHERE spawnname = ? AND server = ?");

--- a/src/main/java/net/cubespace/geSuit/listeners/SpawnMessageListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/SpawnMessageListener.java
@@ -55,6 +55,8 @@ public class SpawnMessageListener implements Listener {
             SpawnManager.setNewPlayerSpawn(PlayerManager.getPlayer(in.readUTF(), true), new Location(s.getInfo().getName(), in.readUTF(), in.readDouble(), in.readDouble(), in.readDouble(), in.readFloat(), in.readFloat()));
         } else if (task.equals("SetProxySpawn")) {
             SpawnManager.setProxySpawn(PlayerManager.getPlayer(in.readUTF(), true), new Location(s.getInfo().getName(), in.readUTF(), in.readDouble(), in.readDouble(), in.readDouble(), in.readFloat(), in.readFloat()));
+        } else if (task.equals("SendToArgSpawn")) {
+            SpawnManager.sendPlayerToArgSpawn(PlayerManager.getPlayer(in.readUTF(), true), in.readUTF(), in.readUTF());
         } else if (task.equals("SendVersion")) {
             LoggingManager.log(in.readUTF());
         }

--- a/src/main/java/net/cubespace/geSuit/managers/SpawnManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/SpawnManager.java
@@ -117,4 +117,20 @@ public class SpawnManager {
 
         ProxySpawn = l;
     }
+
+    public static void sendPlayerToArgSpawn(GSPlayer player, String spawn, String server) {
+        Location targetSpawn;
+        if (server.isEmpty()) {
+            targetSpawn = DatabaseManager.spawns.getSpawn(spawn);
+        } else {
+            targetSpawn = DatabaseManager.spawns.getServerSpawn(spawn, server);
+        }
+
+        if (targetSpawn == null) {
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SPAWN_DOES_NOT_EXIST);
+            return;
+        }
+
+        TeleportToLocation.execute(player, targetSpawn);
+    }
 }


### PR DESCRIPTION
This is used for the /warpspawn command added into the geSuitSpawn
plugin.
Adds an additional function to lookup a spawn point with both server name and spawn name used as query parameters.