### PR TITLE
Fix cross-server teleport issues

### DIFF
--- a/modules/spawn/src/main/java/net/cubespace/geSuiteSpawn/managers/SpawnManager.java
+++ b/modules/spawn/src/main/java/net/cubespace/geSuiteSpawn/managers/SpawnManager.java
@@ -139,11 +139,16 @@ public class SpawnManager extends DataManager {
 
     public void sendPlayerToWorldSpawn(CommandSender sender) {
         Player p = ( Player ) sender;
+        Location l = getPlayerWorldSpawn(p);
+        p.teleport(l);
+    }
+
+    public static Location getPlayerWorldSpawn(Player p) {
         Location l = getWorldSpawn( p.getWorld() );
         if ( l == null ) {
-            p.teleport( p.getWorld().getSpawnLocation() );
+            return p.getWorld().getSpawnLocation();
         } else {
-            p.teleport( getWorldSpawn( p.getWorld() ) );
+            return getWorldSpawn(p.getWorld());
         }
     }
 

--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
@@ -1,6 +1,5 @@
 package net.cubespace.geSuitTeleports.listeners;
 
-import net.cubespace.geSuit.managers.LoggingManager;
 import net.cubespace.geSuitTeleports.geSuitTeleports;
 import net.cubespace.geSuitTeleports.managers.TeleportsManager;
 import net.cubespace.geSuiteSpawn.managers.SpawnManager;
@@ -33,33 +32,11 @@ public class TeleportsListener implements Listener {
 	@EventHandler
 	public void playerConnect (PlayerSpawnLocationEvent e){
 		if (e.getPlayer().hasMetadata("NPC")) return; // Ignore NPCs
-		if(TeleportsManager.pendingTeleports.containsKey(e.getPlayer().getName())){
-			Player t = TeleportsManager.pendingTeleports.get(e.getPlayer().getName());
-			TeleportsManager.pendingTeleports.remove(e.getPlayer().getName());
-			if ((t == null) || (!t.isOnline())) {
-				e.getPlayer().sendMessage(geSuitTeleports.no_longer_online);
-				return;
-			}
-			TeleportsManager.ignoreTeleport.add(e.getPlayer());
-			Location loc = t.getLocation();
-            if (manager.getUtil().worldGuardTpAllowed(loc, e.getPlayer())) {
-				e.setSpawnLocation(loc);
-			}else{
-				LoggingManager.debug(e.getPlayer().getName() + "being sent to spawn due to a worldguard block at " + loc.toString());
-				e.setSpawnLocation(e.getPlayer().getWorld().getSpawnLocation());
-			}
-		}else if (TeleportsManager.pendingTeleportLocations.containsKey(e.getPlayer().getName())){
-			Location l = TeleportsManager.pendingTeleportLocations.get(e.getPlayer().getName());
-			TeleportsManager.ignoreTeleport.add(e.getPlayer());
-            if (manager.getUtil().worldGuardTpAllowed(l, e.getPlayer())) {
-				e.setSpawnLocation(l);
-			}else{
-				if((geSuitTeleports.geSuitSpawns) && (SpawnManager.hasWorldSpawn(e.getSpawnLocation().getWorld()))){
-                    spawnsManager.sendPlayerToWorldSpawn(e.getPlayer());
-				}else{
-					e.setSpawnLocation(e.getSpawnLocation().getWorld().getSpawnLocation());
-				}
-			}
+
+		// Check if there's any pending teleports for the player
+		Location loc = manager.getPendingTeleportLocation(e.getPlayer(), e.getSpawnLocation().getWorld().getSpawnLocation());
+		if (loc != null) {
+			e.setSpawnLocation(loc);
 		}
 	}
 	
@@ -100,12 +77,19 @@ public class TeleportsListener implements Listener {
         TeleportsManager.ignoreTeleport.add(e.getEntity());
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void playerJoin(final PlayerJoinEvent event) {
-		if (event.getPlayer().hasMetadata("NPC")) return; // Ignore NPCs
-	    // This is to prevent recording the back location when teleporting across servers, on the destination server
-        TeleportsManager.ignoreTeleport.add(event.getPlayer());
-        Bukkit.getScheduler().runTaskLaterAsynchronously(instance, () -> TeleportsManager.ignoreTeleport.remove(event.getPlayer()), 20);
-	}
+	@EventHandler(priority = EventPriority.LOW)
+	public void playerJoin(final PlayerJoinEvent e) {
+		if (e.getPlayer().hasMetadata("NPC")) return; // Ignore NPCs
 
+		// Check if there's any pending teleports for the player
+		Player p = e.getPlayer();
+		Location loc = manager.getPendingTeleportLocation(p, e.getPlayer().getWorld().getSpawnLocation());
+		if (loc != null) {
+			p.teleport(loc);
+		} else {
+			// This is to prevent recording the back location when teleporting across servers, on the destination server
+			TeleportsManager.ignoreTeleport.add(p);
+		}
+		Bukkit.getScheduler().runTaskLaterAsynchronously(instance, () -> TeleportsManager.ignoreTeleport.remove(p), 20);
+	}
 }

--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
@@ -5,19 +5,18 @@ import net.cubespace.geSuit.managers.DataManager;
 import net.cubespace.geSuitTeleports.geSuitTeleports;
 import net.cubespace.geSuitTeleports.utils.LocationUtil;
 
+import net.cubespace.geSuiteSpawn.managers.SpawnManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginManager;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-
 
 public class TeleportsManager extends DataManager {
     public static final HashMap<String, Player> pendingTeleports = new HashMap<>();
@@ -410,5 +409,41 @@ public class TeleportsManager extends DataManager {
 
         instance.sendMessage(b);
 
+    }
+
+    public Location getPendingTeleportLocation(Player player, Location fallbackLocation) {
+        if (pendingTeleports.containsKey(player.getName())) {
+            Player t = pendingTeleports.get(player.getName());
+            pendingTeleports.remove(player.getName());
+            if ((t == null) || (!t.isOnline())) {
+                // Do nothing if player is not online
+                return null;
+            }
+            ignoreTeleport.add(player);
+            Location loc = t.getLocation();
+            if (getUtil().worldGuardTpAllowed(loc, player)) {
+                return loc;
+            } else {
+                return player.getWorld().getSpawnLocation();
+            }
+        } else if (pendingTeleportLocations.containsKey(player.getName())) {
+            Location loc = pendingTeleportLocations.get(player.getName());
+            pendingTeleportLocations.remove(player.getName());
+            if (!player.isOnline()) {
+                // Do nothing if player is not online
+                return null;
+            }
+            ignoreTeleport.add(player);
+            if (getUtil().worldGuardTpAllowed(loc, player)) {
+                return loc;
+            } else {
+                if ((geSuitTeleports.geSuitSpawns) && (SpawnManager.hasWorldSpawn(player.getWorld()))) {
+                    return SpawnManager.getPlayerWorldSpawn(player);
+                } else {
+                    return fallbackLocation;
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
We've recently been experiencing issues with cross-server teleports, mostly with homes and warps. The problem usually occurs when there is no player on the destination server. I've done a lot of tracing, debugging and testing to find the cause.

Turns out there seems to be an inconsistent timing of when a plugin message is sent/received over a _joining_ player's connection. If the player is the first one to join a server, sometimes the message is received _before_ `PlayerSpawnLocationEvent` and sometimes after. When the message is received after spawn event, the joining the player is sometimes _not_ seen as online so the teleport is queued, but the spawn event has already happened so it's never used.

This change allows for an additional chance for the queued/pending teleport to be picked up by the `PlayerJoinEvent` event and get processed as it would with a normal teleport (setting spawn location isn't possible at that point).

The behaviour of this used to work but something either in proxy or server event handling has changed which has caused this to break.