### PR TITLE
Fix teleport back on quit

### DIFF
--- a/modules/bukkitModule/src/main/java/net/cubespace/geSuit/BukkitModule.java
+++ b/modules/bukkitModule/src/main/java/net/cubespace/geSuit/BukkitModule.java
@@ -2,7 +2,9 @@ package net.cubespace.geSuit;
 
 import net.cubespace.geSuit.managers.LoggingManager;
 import net.cubespace.geSuit.task.PluginMessageTask;
+import net.cubespace.geSuit.utils.Utilities;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
@@ -114,5 +116,24 @@ public abstract class BukkitModule extends JavaPlugin {
     
     public void sendMessage(ByteArrayOutputStream b){
         new PluginMessageTask(b,this).runTaskAsynchronously(this);
+    }
+
+    /**
+     * Immediately send a plugin message via the provided player. This bypasses
+     * the asynchronous {@link PluginMessageTask} to ensure the message is sent
+     * before the player disconnects.
+     *
+     * @param player the player to send the message through
+     * @param b      the message data
+     */
+    public void sendMessage(Player player, ByteArrayOutputStream b){
+        if(player != null && player.isOnline()){
+            player.sendPluginMessage(this, getCHANNEL_NAME(), b.toByteArray());
+            LoggingManager.debug("[" + getName() + "] " +
+                    Utilities.dumpPacket(getCHANNEL_NAME(), "SEND", b.toByteArray()));
+        }else{
+            LoggingManager.debug("[" + getName() + "] Unable to send Message-No player online.- " +
+                    Utilities.dumpPacket(getCHANNEL_NAME(), "SEND", b.toByteArray()));
+        }
     }
 }

--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
@@ -189,7 +189,7 @@ public class TeleportsManager extends DataManager {
             out.writeDouble(l.getZ());
             out.writeFloat(l.getYaw());
             out.writeFloat(l.getPitch());
-            instance.sendMessage(b);
+            instance.sendMessage(p, b);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -209,7 +209,7 @@ public class TeleportsManager extends DataManager {
             out.writeFloat(l.getPitch());
             //todo the boolean was being passed to the message sender which was ignoring it..need to
             // evaluate its importance
-            instance.sendMessage(b);
+            instance.sendMessage(p, b);
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- add `sendMessage(Player, ByteArrayOutputStream)` to BukkitModule to immediately send plugin messages
- send teleport back/death messages through the leaving player so they are delivered before disconnect

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429a02ab64832c854128d11436b410