### PR TITLE
Fix /back after death

### DIFF
--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
@@ -71,12 +72,17 @@ public class TeleportsListener implements Listener {
         manager.sendTeleportBackLocation(e.getPlayer(), empty);
 	}
 	
-	@EventHandler(ignoreCancelled = true)
-	public void playerDeath(PlayerDeathEvent e){
-		if (e.getEntity().hasMetadata("NPC")) return; // Ignore NPCs
+        @EventHandler(ignoreCancelled = true)
+        public void playerDeath(PlayerDeathEvent e){
+                if (e.getEntity().hasMetadata("NPC")) return; // Ignore NPCs
         manager.sendDeathBackLocation(e.getEntity());
         TeleportsManager.ignoreTeleport.add(e.getEntity());
-	}
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        public void playerRespawn(PlayerRespawnEvent e){
+                TeleportsManager.ignoreTeleport.remove(e.getPlayer());
+        }
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void playerJoin(final PlayerJoinEvent e) {


### PR DESCRIPTION
## Summary
- handle `PlayerRespawnEvent` so that the first teleport after death records a new back location

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429555c63c832c8b57b9e3488815f6