### PR TITLE
Fix async modification of teleport sets

### DIFF
--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/listeners/TeleportsListener.java
@@ -97,6 +97,6 @@ public class TeleportsListener implements Listener {
 			// This is to prevent recording the back location when teleporting across servers, on the destination server
 			TeleportsManager.ignoreTeleport.add(p);
 		}
-		Bukkit.getScheduler().runTaskLaterAsynchronously(instance, () -> TeleportsManager.ignoreTeleport.remove(p), 20);
-	}
+		Bukkit.getScheduler().runTaskLater(instance, () -> TeleportsManager.ignoreTeleport.remove(p), 20);
+        }
 }

--- a/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
+++ b/modules/teleports/src/main/java/net/cubespace/geSuitTeleports/managers/TeleportsManager.java
@@ -287,7 +287,7 @@ public class TeleportsManager extends DataManager {
         } else {
             pendingTeleports.put( player, t );
             //clear pending teleport if they dont connect
-            Bukkit.getScheduler().runTaskLaterAsynchronously(instance, () -> pendingTeleports.remove(player), 100L);
+            Bukkit.getScheduler().runTaskLater(instance, () -> pendingTeleports.remove(player), 100L);
         }
     }
 
@@ -331,7 +331,7 @@ public class TeleportsManager extends DataManager {
         } else {
             pendingTeleportLocations.put( player, t );
             //clear pending teleport if they dont connect
-            Bukkit.getScheduler().runTaskLaterAsynchronously(instance, () -> pendingTeleportLocations.remove(player), 100L);
+            Bukkit.getScheduler().runTaskLater(instance, () -> pendingTeleportLocations.remove(player), 100L);
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid async modifications of teleport collections
- fix indentation on player join teleport cleanup

## Testing
- (no tests run per instructions)

------
https://chatgpt.com/codex/tasks/task_e_6842d319af80832cb3200a669dec880e